### PR TITLE
Fixing inconsistency in PropertyUnitData.xml

### DIFF
--- a/computable/XML/PropertyUnitData.xml
+++ b/computable/XML/PropertyUnitData.xml
@@ -24,7 +24,7 @@
   <Property id="1" Text="Mass" openEHR="124" />
   <Property id="2" Text="Time" openEHR="128" />
   <Property id="3" Text="Temperature" openEHR="127" />
-  <Property id="4" Text="Electrical current" openEHR="334" />
+  <Property id="4" Text="Electric current" openEHR="334" />
   <Property id="5" Text="Area" openEHR="335" />
   <Property id="6" Text="Volume" openEHR="129" />
   <Property id="7" Text="Flow Rate, Volume" openEHR="126" />
@@ -67,9 +67,9 @@
   <Property id="46" Text="Specific Heat, Gas Constant" openEHR="371" />
   <Property id="47" Text="Thermal Conductivity" openEHR="372" />
   <Property id="48" Text="Heat Transfer Coefficient" openEHR="373" />
-  <Property id="49" Text="Electrical Potential" openEHR="374" />
+  <Property id="49" Text="Electric Potential" openEHR="374" />
   <Property id="50" Text="Resistance" openEHR="375" />
-  <Property id="52" Text="Electrical Field Strength" openEHR="377" />
+  <Property id="52" Text="Electric Field Strength" openEHR="377" />
   <Property id="53" Text="Magnetic Flux" openEHR="378" />
   <Property id="54" Text="Inductance" openEHR="379" />
   <Property id="56" Text="Qualified real" openEHR="380" />
@@ -82,12 +82,12 @@
   <Property id="63" Text="Work" openEHR="130" />
   <Property id="64" Text="&lt;not set&gt;" openEHR="118" />
   <Property id="65" Text="Mass (Units)" openEHR="445" />
-  <Property id="66" Text="Electrical charge" openEHR="498" />
+  <Property id="66" Text="Electric charge" openEHR="498" />
   <Property id="67" Text="Light intensity" openEHR="499" />
   <Property id="68" Text="Angle, plane" openEHR="497" />
   <Property id="69" Text="Angle, solid" openEHR="500" />
-  <Property id="70" Text="Electrical capacitance" openEHR="501" />
-  <Property id="71" Text="Electrical conductance" openEHR="502" />
+  <Property id="70" Text="Electric capacitance" openEHR="501" />
+  <Property id="71" Text="Electric conductance" openEHR="502" />
   <Property id="72" Text="Magnetic flux density" openEHR="503" />
   <Property id="73" Text="Luminous flux" openEHR="503" />
   <Property id="74" Text="Illuminance" openEHR="504" />
@@ -95,7 +95,7 @@
   <Property id="76" Text="Energy dose" openEHR="508" />
   <Property id="77" Text="Proportion" openEHR="507" />
   <Property id="78" Text="Glomerular filtration rate" openEHR="586" />
-  <Property id="79" Text="Electrical Potential Time" openEHR="655" />
+  <Property id="79" Text="Electric Potential Time" openEHR="655" />
   <Property id="80" Text="Time Fraction" openEHR="709" />
   <Property id="81" Text="Refractive power" openEHR="685" />
   <Property id="82" Text="Rate of Change - Pressure" openEHR="708" />

--- a/computable/XML/PropertyUnitData.xml
+++ b/computable/XML/PropertyUnitData.xml
@@ -603,7 +603,7 @@
   <Unit property_id="71" Text="S" name="siemens" conversion="1" primary="true" UCUM="S"/>
   <Unit property_id="72" Text="T" name="Tesla" conversion="1" primary="true" UCUM="T"/>
   <Unit property_id="73" Text="lm" name="lumen" conversion="1" primary="true" UCUM="lm"/>
-  <Unit property_id="74" Text="lm/m2" name="Lux" conversion="1" primary="true" UCUM="lx"/>
+  <Unit property_id="74" Text="lx" name="lux" conversion="1" primary="true" UCUM="lx"/>
   <Unit property_id="75" Text="Bq" name="Becquerel" conversion="1" primary="true" UCUM="Bq"/>
   <Unit property_id="76" Text="Gy" name="Gray" conversion="1" primary="true" UCUM="Gy"/>
   <Unit property_id="76" Text="cGy" name="centigray" conversion="1" coefficient="-2" primary="false" UCUM="cGy"/>

--- a/computable/XML/PropertyUnitData.xml
+++ b/computable/XML/PropertyUnitData.xml
@@ -89,8 +89,8 @@
   <Property id="70" Text="Electric capacitance" openEHR="501" />
   <Property id="71" Text="Electric conductance" openEHR="502" />
   <Property id="72" Text="Magnetic flux density" openEHR="503" />
-  <Property id="73" Text="Luminous flux" openEHR="503" />
-  <Property id="74" Text="Illuminance" openEHR="504" />
+  <Property id="73" Text="Luminous flux" openEHR="504" />
+  <Property id="74" Text="Illuminance" openEHR="505" />
   <Property id="75" Text="Radioactivity" openEHR="506" />
   <Property id="76" Text="Energy dose" openEHR="508" />
   <Property id="77" Text="Proportion" openEHR="507" />

--- a/computable/XML/PropertyUnitData.xml
+++ b/computable/XML/PropertyUnitData.xml
@@ -603,6 +603,7 @@
   <Unit property_id="71" Text="S" name="siemens" conversion="1" primary="true" UCUM="S"/>
   <Unit property_id="72" Text="T" name="Tesla" conversion="1" primary="true" UCUM="T"/>
   <Unit property_id="73" Text="lm" name="lumen" conversion="1" primary="true" UCUM="lm"/>
+  <Unit property_id="74" Text="lm/m2" name="Lux" conversion="1" primary="true" UCUM="lx"/>
   <Unit property_id="75" Text="Bq" name="Becquerel" conversion="1" primary="true" UCUM="Bq"/>
   <Unit property_id="76" Text="Gy" name="Gray" conversion="1" primary="true" UCUM="Gy"/>
   <Unit property_id="76" Text="cGy" name="centigray" conversion="1" coefficient="-2" primary="false" UCUM="cGy"/>

--- a/computable/XML/PropertyUnitData.xml
+++ b/computable/XML/PropertyUnitData.xml
@@ -98,8 +98,8 @@
   <Property id="79" Text="Electric Potential Time" openEHR="655" />
   <Property id="80" Text="Time Fraction" openEHR="709" />
   <Property id="81" Text="Refractive power" openEHR="685" />
-  <Property id="82" Text="Rate of Change - Pressure" openEHR="708" />
-  <Property id="84" Text="Rate of Change - Frequency" openEHR="754" />
+  <Property id="82" Text="Rate of Change, Pressure" openEHR="708" />
+  <Property id="84" Text="Rate of Change, Frequency" openEHR="754" />
   <Property id="85" Text="Arbitrary" openEHR="755" />
   <Property id="86" Text="Medication dose rate" openEHR="756" />
   <Property id="87" Text="Spectral power" openEHR="757" />

--- a/computable/XML/en/openehr_terminology.xml
+++ b/computable/XML/en/openehr_terminology.xml
@@ -143,7 +143,7 @@
 		<concept id="344" rubric="Moment inertia, area"/>
 		<concept id="345" rubric="Moment inertia, mass"/>
 		<concept id="340" rubric="Momentum"/>
-		<concept id="346" rubric="Momentum, flow rate"/>
+		<concept id="346" rubric="Momentum flow rate"/>
 		<concept id="343" rubric="Momentum, angular"/>
 		<concept id="363" rubric="Power"/>
 		<concept id="369" rubric="Power density"/>
@@ -166,9 +166,9 @@
 		<concept id="359" rubric="Torque"/>
 		<concept id="338" rubric="Velocity"/>
 		<concept id="341" rubric="Velocity, angular"/>
-		<concept id="360" rubric="Velocity, dynamic"/>
-		<concept id="361" rubric="Velocity, kinematic"/>
-		<concept id="374" rubric="Voltage, electrical"/>
+		<concept id="360" rubric="Viscosity, dynamic"/>
+		<concept id="361" rubric="Viscosity, kinematic"/>
+		<concept id="374" rubric="Electric potential"/>
 		<concept id="129" rubric="Volume"/>
 		<concept id="130" rubric="Work"/>
 		<concept id="685" rubric="Refractive power"/>

--- a/computable/XML/en/openehr_terminology.xml
+++ b/computable/XML/en/openehr_terminology.xml
@@ -172,6 +172,16 @@
 		<concept id="129" rubric="Volume"/>
 		<concept id="130" rubric="Work"/>
 		<concept id="685" rubric="Refractive power"/>
+		<concept id="118" rubric="&lt;not set&gt;"/>
+		<concept id="709" rubric="Time fraction"/>
+		<concept id="708" rubric="Rate of change, pressure"/>
+		<concept id="754" rubric="Rate of change, frequency"/>
+		<concept id="755" rubric="Arbitrary"/>
+		<concept id="756" rubric="Medication dose rate"/>
+		<concept id="757" rubric="Spectral power"/>
+		<concept id="758" rubric="Spectral power density"/>
+		<concept id="759" rubric="Pace"/>
+		<concept id="760" rubric="Enzyme activity"/>
 	</group>
 	<group name="version lifecycle state">
 		<concept id="532" rubric="complete"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->

--- a/computable/XML/es/openehr_terminology.xml
+++ b/computable/XML/es/openehr_terminology.xml
@@ -166,12 +166,22 @@
         <concept id="359" rubric="Torque"/>
         <concept id="338" rubric="Velocidad"/>
         <concept id="341" rubric="Velocidad, angular"/>
-        <concept id="360" rubric="Velocidad, dinámica"/>
-        <concept id="361" rubric="Velocidad, cinemática"/>
+        <concept id="360" rubric="Viscosity, dynamic (en)"/>
+        <concept id="361" rubric="Viscosity, kinematic (en)"/>
         <concept id="374" rubric="Voltaje, eléctrico"/>
         <concept id="129" rubric="Volumen"/>
         <concept id="130" rubric="Trabajo"/>
         <concept id="685" rubric="Poder refractivo"/>
+        <concept id="118" rubric="&lt;not set&gt; (en)"/>
+        <concept id="709" rubric="Time fraction (en)"/>
+        <concept id="708" rubric="Rate of change, pressure (en)"/>
+        <concept id="754" rubric="Rate of change, frequency (en)"/>
+        <concept id="755" rubric="Arbitrary (en)"/>
+        <concept id="756" rubric="Medication dose rate (en)"/>
+        <concept id="757" rubric="Spectral power (en)"/>
+        <concept id="758" rubric="Spectral power density (en)"/>
+        <concept id="759" rubric="Pace (en)"/>
+        <concept id="760" rubric="Enzyme activity (en)"/>
     </group>
     <group name="version lifecycle state">
         <concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->

--- a/computable/XML/ja/openehr_terminology.xml
+++ b/computable/XML/ja/openehr_terminology.xml
@@ -166,12 +166,22 @@
 		<concept id="359" rubric="トルク"/>
 		<concept id="338" rubric="速度"/>
 		<concept id="341" rubric="角速度"/>
-		<concept id="360" rubric="速度（動的）"/>
-		<concept id="361" rubric="速度（運動）"/>
+		<concept id="360" rubric="Viscosity, dynamic (en)"/>
+		<concept id="361" rubric="Viscosity, kinematic (en)"/>
 		<concept id="374" rubric="電圧"/>
 		<concept id="129" rubric="容積"/>
 		<concept id="130" rubric="仕事量"/>
 		<concept id="685" rubric="屈折力"/>
+		<concept id="118" rubric="&lt;not set&gt; (en)"/>
+		<concept id="709" rubric="Time fraction (en)"/>
+		<concept id="708" rubric="Rate of change, pressure (en)"/>
+		<concept id="754" rubric="Rate of change, frequency (en)"/>
+		<concept id="755" rubric="Arbitrary (en)"/>
+		<concept id="756" rubric="Medication dose rate (en)"/>
+		<concept id="757" rubric="Spectral power (en)"/>
+		<concept id="758" rubric="Spectral power density (en)"/>
+		<concept id="759" rubric="Pace (en)"/>
+		<concept id="760" rubric="Enzyme activity (en)"/>
 	</group>
 	<group name="version lifecycle state">
 		<concept id="532" rubric="完了"/>

--- a/computable/XML/pt/openehr_terminology.xml
+++ b/computable/XML/pt/openehr_terminology.xml
@@ -166,12 +166,22 @@
 		<concept id="359" rubric="torque"/>
 		<concept id="338" rubric="velocidade"/>
 		<concept id="341" rubric="velocidade angular"/>
-		<concept id="360" rubric="velocidade, dinâmica"/>
-		<concept id="361" rubric="veocidade, cinemática"/>
+		<concept id="360" rubric="Viscosity, dynamic (en)"/>
+		<concept id="361" rubric="Viscosity, kinematic (en)"/>
 		<concept id="374" rubric="voltagem, elétrica"/>
 		<concept id="129" rubric="volume"/>
 		<concept id="130" rubric="trabalho"/>
 		<concept id="685" rubric="potência dióptrica"/>
+		<concept id="118" rubric="&lt;not set&gt; (en)"/>
+		<concept id="709" rubric="Time fraction (en)"/>
+		<concept id="708" rubric="Rate of change, pressure (en)"/>
+		<concept id="754" rubric="Rate of change, frequency (en)"/>
+		<concept id="755" rubric="Arbitrary (en)"/>
+		<concept id="756" rubric="Medication dose rate (en)"/>
+		<concept id="757" rubric="Spectral power (en)"/>
+		<concept id="758" rubric="Spectral power density (en)"/>
+		<concept id="759" rubric="Pace (en)"/>
+		<concept id="760" rubric="Enzyme activity (en)"/>
 	</group>
 	<group name="estado de ciclo de vida de versão">
 		<concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->


### PR DESCRIPTION
Fixing inconsistency between PropertyUnitData.xml and property-rubric of openehr_terminology.xml (relates to SPECTERM-24).